### PR TITLE
Batch of peer review fixes

### DIFF
--- a/Test.S
+++ b/Test.S
@@ -2,6 +2,7 @@ LDI r29, 0x14
 INC r29
 LDI r28, 0xAF
 INC r28
-ADD r28, r29
 @@printregs
+ADD r28, r29
 
+@@printregs

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-javac -d bin/ src/Interpreter/*.java
+
+javac -d bin/ -sourcepath src src/Interpreter/*.java
 
 stringZ="java -cp bin Interpreter.Main"
 

--- a/src/Interpreter/ASMFileReader.java
+++ b/src/Interpreter/ASMFileReader.java
@@ -79,15 +79,21 @@ public class ASMFileReader {
 	}
 
 	public String[] parseAssemblyLine( String lineOfAssembly ) {
+		
+		if(lineOfAssembly.isBlank()) {
+			String [] blank = {""};
+			return blank;
+		}
+		
 		int indexOfString = 0;
 		String opCode = "";
 		
 		while(lineOfAssembly.charAt(indexOfString) != ' ') {
-			if( indexOfString == lineOfAssembly.length()) {
-				break;
-			}
 			opCode += lineOfAssembly.charAt(indexOfString);
 			indexOfString++;
+			if(lineOfAssembly.length() == indexOfString) {
+				break;
+			}
 			
 		}
 		
@@ -105,7 +111,11 @@ public class ASMFileReader {
 	public void parseAllAssemblyLines() {
 		for( int i = 0; i < assemblyLines.size(); i++ ) {
 			String[] parsedLine = parseAssemblyLine(assemblyLines.get(i));
-			parsedAssemblyLines.add(parsedLine);
+			
+			if(!parsedLine[0].isBlank()) {
+				parsedAssemblyLines.add(parsedLine);
+			}
+			
 		}
 	}
 	

--- a/src/Interpreter/ATmega328PCPU.java
+++ b/src/Interpreter/ATmega328PCPU.java
@@ -92,6 +92,10 @@ public class ATmega328PCPU extends AbstractCPU {
 			ATmega328PCPUState oldCPU = new ATmega328PCPUState(this.currentState);
 
 			this.CPUStates.add(oldCPU);
+			
+			if(this.debugFlag) {
+				System.out.println(InstructionToExecute.getType());
+			}
 
 			switch (InstructionToExecute.getType()) {
 			case HWInstruction:
@@ -126,21 +130,6 @@ public class ATmega328PCPU extends AbstractCPU {
 			throw new Exception("Invalid or Unimplemented Macro: " + opcode);
 		}
 
-	}
-
-	private void runMacro(String opcode) throws Exception {
-		
-		
-		switch(opcode) {
-		
-		case "@@printregs":
-			System.out.println(this.toString());
-			return;
-			
-		default:
-			throw new Exception("Invalid or Unimplemented Macro: " + opcode);
-		}
-		
 	}
 
 

--- a/src/Interpreter/ATmega328PCPUState.java
+++ b/src/Interpreter/ATmega328PCPUState.java
@@ -116,7 +116,6 @@ public class ATmega328PCPUState extends AbstractCPUState {
 
 		throw new Exception("Attempted to Write to Invalid Register '" + register + "'");
 	
-		
 	}
 
 	public Integer getRegister(String register) {

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,3 +1,3 @@
 module Projct {
-	requires org.junit.jupiter.api;
+	//requires org.junit.jupiter.api;
 }


### PR DESCRIPTION
This is a batch of fixes from issues encountered during peer review. Fixes made:

-Fixed javac buildpath issue allowing code to compile to class correctly
-Removed redunant method in ATMega328PCPU preventing compilation on CLI
-ASMFileReader no longer stops reading after an assembly macro or whitespace
-Removed JUnit from module info. Chose to remove it because it is a developer dependency rather than a production dependency. Some googling around says that with ant, you might be able to mark this as a "developer dependency" but it isn't super apparent if this is possible with vanilla Java.